### PR TITLE
MWPW-178440: 3-in-1 link transformation not working for US-ROW links

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -763,6 +763,18 @@ function appendExtraOptions(url, extraOptions) {
   return url;
 }
 
+export function applyPromo(url) {
+  const { mep } = getConfig();
+  const promoModal = mep?.inBlock?.merch?.fragments?.[url.pathname];
+  try {
+    const promoUrl = new URL(promoModal?.content);
+    return promoUrl;
+  } catch (e) {
+    log?.error('Failed to apply promo to external modal', e);
+  }
+  return url;
+}
+
 // TODO this should migrate to checkout.js buildCheckoutURL
 export function appendDexterParameters(url, extraOptions, el) {
   const isRelativePath = url.startsWith('/');
@@ -775,6 +787,7 @@ export function appendDexterParameters(url, extraOptions, el) {
     window.lana?.log(`Invalid URL ${url} : ${err}`);
     return url;
   }
+  absoluteUrl = applyPromo(absoluteUrl);
   absoluteUrl = appendExtraOptions(absoluteUrl, extraOptions);
   absoluteUrl = appendTabName(absoluteUrl, el);
   return isRelativePath

--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -66,6 +66,9 @@ export const createLinkMarkup = (
       if (workflowStep && workflowStep !== defaults.checkoutWorkflowStep) {
         params.set('workflowStep', workflowStep);
       }
+      if (options.modal) params.set('modal', options.modal);
+      if (options.entitlement) params.set('entitlement', options.entitlement);
+      if (options.upgrade) params.set('upgrade', options.upgrade);
     } else {
       const {
         displayRecurrence,
@@ -258,6 +261,7 @@ export async function loadOstEnv() {
     wcsApiKey: WCS_API_KEY,
     ctaTextOption,
     resolvePriceTaxFlags,
+    modalsAndEntitlements: true,
   };
 }
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -893,6 +893,17 @@ describe('Merch Block', () => {
       expect(setCtaHash()).to.be.undefined;
     });
 
+    it('applyDexterPromo: applies promo to external modal', () => {
+      const url = 'https://www.adobe.com/plans-fragments/modals/all-apps/master.modal.html';
+      const promoUrl = 'https://www.adobe.com/plans-fragments/modals/all-apps/black-friday.modal.html';
+      setConfig({
+        ...config,
+        mep: { inBlock: { merch: { fragments: { '/plans-fragments/modals/all-apps/master.modal.html': { content: promoUrl } } } } },
+      });
+      const resultUrl = appendDexterParameters(url);
+      expect(resultUrl).to.equal(promoUrl);
+    });
+
     const MODAL_URLS = [
       {
         url: 'https://www.adobe.com/mini-plans/illustrator1.html?mid=ft&web=1',

--- a/test/blocks/ost/ost.test.html.js
+++ b/test/blocks/ost/ost.test.html.js
@@ -81,6 +81,7 @@ describe('OST: loadOstEnv', async () => {
       environment: WCS_ENV,
       language,
       wcsApiKey: WCS_API_KEY,
+      modalsAndEntitlements: true,
     });
   });
 
@@ -252,6 +253,15 @@ describe('OST: merch link creation', () => {
       const ctaText = texts.try;
       const link = createLink({ ctaText, promo, type });
       assertLink(link, perpM2M, { osi, promo, type }, ctaText);
+    });
+
+    it('with custom options', async () => {
+      const ctaText = texts.try;
+      const modal = 'd2p';
+      const entitlement = 'true';
+      const upgrade = 'false';
+      const link = createLink({ ctaText, modal, entitlement, upgrade, type });
+      assertLink(link, perpM2M, { osi, modal, entitlement, upgrade, type }, ctaText);
     });
   });
 


### PR DESCRIPTION
This PR adds the ability to customize the checkout modal URL when the 3-in-1 experience is disabled.
When users click the checkout CTA with the 3-in-1 experience disabled, the modal now supports configurable in MEP page URLs instead of using a fixed default.

How to make this change:
1. In the promotion manifest add:
- The Action column: `replace`
- The Selector column: `in-block merch: /here add the URL that has to be replaced/`
- The All column: `here add the URL you want to see`
See example [here](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B01A20532-FBE1-4FA3-BED6-CAC06966241F%7D&file=old-modal-promo.xlsx&action=default&mobileredirect=true).

Resolves: [MWPW-178440](https://jira.corp.adobe.com/browse/MWPW-178440)

**Test URLs:**

Before:
- https://main--milo--adobecom.aem.live/drafts/mirafedas/promos/old-modal-promo?mep=/fragments/mirafedas/promos/2025/old-modal-promo.json&martech=off&georouting=off

After: 
- https://mwpw-178440-modals-for-promo--milo--mirafedas.aem.live/drafts/mirafedas/promos/old-modal-promo?mep=/fragments/mirafedas/promos/2025/old-modal-promo.json&martech=off&georouting=off

Note: originally implemented in this PR: https://github.com/adobecom/milo/pull/4873



