### PR TITLE
MWPW-182221: Sanitized post message data for XSS prevention

### DIFF
--- a/libs/blocks/merch/three-in-one.js
+++ b/libs/blocks/merch/three-in-one.js
@@ -20,6 +20,74 @@ export const LANA_OPTIONS = {
   tags: 'three-in-one',
 };
 
+export const sanitizeTarget = (target) => {
+  if (!target || typeof target !== 'string') return '_blank';
+  const trimmedTarget = target.trim();
+  const normalizedTarget = trimmedTarget
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/g, '');
+  if (['_blank', '_self', '_parent', '_top'].includes(normalizedTarget)) {
+    return normalizedTarget;
+  }
+  if (/^[a-zA-Z0-9_-]+$/.test(normalizedTarget)) {
+    return normalizedTarget;
+  }
+  return '_blank';
+};
+
+export const decodeUrl = (url) => {
+  if (!url || typeof url !== 'string') return null;
+  let decodedUrl = url;
+  let previousUrl;
+  let iterations = 0;
+  const maxIterations = 5;
+  while (iterations < maxIterations && decodedUrl !== previousUrl) {
+    previousUrl = decodedUrl;
+    try {
+      decodedUrl = decodeURIComponent(decodedUrl);
+    } catch (e) {
+      break;
+    }
+    iterations += 1;
+  }
+  return decodedUrl;
+};
+
+export const normalizeUrl = (url) => {
+  const normalizedUrl = url
+  // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1F\x7F]/g, '')
+  // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/g, '')
+    .trim();
+
+  const dangerousProtocols = /^(javascript|data|vbscript|file|about|chrome|chrome-extension|filesystem|blob|mailto|tel|sms):/i;
+  return dangerousProtocols.test(normalizedUrl) ? null : normalizedUrl;
+};
+
+export const isHttps = (url) => {
+  if (/^https?:\/\//i.test(url)) {
+    try {
+      const urlObj = new URL(url);
+      if (!['https:'].includes(urlObj.protocol)) return null;
+      return urlObj.href;
+    } catch (e) {
+      return null;
+    }
+  }
+  const isRelativeUrl = /^\//.test(url);
+  return isRelativeUrl ? url : null;
+};
+
+export const sanitizeUrl = (url) => {
+  if (!url || typeof url !== 'string') return null;
+  const decodedUrl = decodeUrl(url.trim());
+  const normalizedUrl = normalizeUrl(decodedUrl);
+  return isHttps(normalizedUrl);
+};
+
 export const reloadIframe = ({ iframe, theme, msgWrapper, handleTimeoutError }) => {
   if (!msgWrapper || !iframe || !theme || !handleTimeoutError) return;
   msgWrapper.remove();
@@ -61,7 +129,8 @@ export const showErrorMsg = async ({ iframe, miloIframe, showBtn, theme, handleT
   }
 };
 
-export const handle3in1IFrameEvents = ({ data: msgData }) => {
+export const handle3in1IFrameEvents = ({ data: msgData, origin }) => {
+  if (!['https://commerce.adobe.com', 'https://commerce-stg.adobe.com'].includes(origin)) return;
   let parsedMsg = null;
   try {
     parsedMsg = JSON.parse(msgData);
@@ -70,7 +139,7 @@ export const handle3in1IFrameEvents = ({ data: msgData }) => {
   }
   const { app, subType, data } = parsedMsg || {};
   if (app !== 'ucv3') return;
-  window.lana?.log(`3-in-1 modal: ${subType}, data: ${JSON.stringify(data)}`);
+  window.lana?.log(`3-in-1 modal: ${subType}`);
   const threeInOne = document.querySelector('.three-in-one');
   const closeBtn = threeInOne?.querySelector('.dialog-close');
   const iframe = threeInOne?.querySelector('iframe');
@@ -92,12 +161,19 @@ export const handle3in1IFrameEvents = ({ data: msgData }) => {
     case MSG_SUBTYPE.SWITCH:
     case MSG_SUBTYPE.RETURN_BACK:
       if (data?.externalUrl && data.target) {
-        window.open(data.externalUrl, data.target);
+        const sanitizedUrl = sanitizeUrl(data.externalUrl);
+        const sanitizedTarget = sanitizeTarget(data.target);
+        if (sanitizedUrl) {
+          window.open(sanitizedUrl, sanitizedTarget);
+        }
       }
       break;
     case MSG_SUBTYPE.Close:
       if (data?.actionRequired && data?.actionUrl) {
-        window.open(data.actionUrl);
+        const sanitizedActionUrl = sanitizeUrl(data.actionUrl);
+        if (sanitizedActionUrl) {
+          window.open(sanitizedActionUrl);
+        }
       }
       relatedMerchCards.forEach((card) => {
         card?.closest('merch-card')?.dispatchEvent(new CustomEvent(

--- a/test/blocks/merch/three-in-one.test.js
+++ b/test/blocks/merch/three-in-one.test.js
@@ -14,6 +14,11 @@ const {
   handle3in1IFrameEvents,
   handleTimeoutError,
   createContent,
+  decodeUrl,
+  normalizeUrl,
+  isHttps,
+  sanitizeUrl,
+  sanitizeTarget,
   default: openThreeInOneModal,
 } = await import('../../../libs/blocks/merch/three-in-one.js');
 
@@ -105,7 +110,7 @@ describe('Three-in-One Modal', () => {
         app: 'ucv3',
         subType: MSG_SUBTYPE.AppLoaded,
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
       const iframe = document.querySelector('iframe');
       const theme = document.querySelector('sp-theme');
       const closeBtn = document.querySelector('.dialog-close');
@@ -124,7 +129,7 @@ describe('Three-in-One Modal', () => {
         app: 'ucv3',
         subType: MSG_SUBTYPE.Close,
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
       expect(closeEvent.calledOnce).to.be.true;
     });
 
@@ -134,12 +139,12 @@ describe('Three-in-One Modal', () => {
         app: 'ucv3',
         subType: MSG_SUBTYPE.EXTERNAL,
         data: {
-          externalUrl: 'https://example.com',
+          externalUrl: 'https://commerce.adobe.com/',
           target: '_blank',
         },
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
-      expect(windowOpenSpy.calledWith('https://example.com', '_blank')).to.be.true;
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
+      expect(windowOpenSpy.calledWith('https://commerce.adobe.com/', '_blank')).to.be.true;
     });
 
     it('should handle SWITCH message and open window with external URL', () => {
@@ -148,12 +153,12 @@ describe('Three-in-One Modal', () => {
         app: 'ucv3',
         subType: MSG_SUBTYPE.SWITCH,
         data: {
-          externalUrl: 'https://example.com',
+          externalUrl: 'https://commerce.adobe.com/',
           target: '_blank',
         },
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
-      expect(windowOpenSpy.calledWith('https://example.com', '_blank')).to.be.true;
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
+      expect(windowOpenSpy.calledWith('https://commerce.adobe.com/', '_blank')).to.be.true;
     });
 
     it('should handle RETURN_BACK message and open window with external URL', () => {
@@ -162,12 +167,12 @@ describe('Three-in-One Modal', () => {
         app: 'ucv3',
         subType: MSG_SUBTYPE.RETURN_BACK,
         data: {
-          externalUrl: 'https://example.com',
+          externalUrl: 'https://commerce.adobe.com/',
           target: '_blank',
         },
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
-      expect(windowOpenSpy.calledWith('https://example.com', '_blank')).to.be.true;
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
+      expect(windowOpenSpy.calledWith('https://commerce.adobe.com/', '_blank')).to.be.true;
     });
 
     it('should handle Close message with action URL', () => {
@@ -177,11 +182,11 @@ describe('Three-in-One Modal', () => {
         subType: MSG_SUBTYPE.Close,
         data: {
           actionRequired: true,
-          actionUrl: 'https://example.com/action',
+          actionUrl: 'https://subdomain.adobe.com/action',
         },
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
-      expect(windowOpenSpy.calledWith('https://example.com/action')).to.be.true;
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
+      expect(windowOpenSpy.calledWith('https://subdomain.adobe.com/action')).to.be.true;
     });
 
     it('should dispatch merch-modal:addon-and-quantity-update event on Close message with cart items', () => {
@@ -200,13 +205,41 @@ describe('Three-in-One Modal', () => {
         subType: MSG_SUBTYPE.Close,
         data: { state: { cart: { items: ['item1', 'item2'] } } },
       };
-      handle3in1IFrameEvents({ data: JSON.stringify(message) });
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
 
       expect(eventSpy.calledOnce).to.be.true;
       expect(eventSpy.firstCall.args[0].detail).to.deep.equal({
         id: 'test-modal-id',
         items: ['item1', 'item2'],
       });
+    });
+
+    it('should fail silently if invalid data is passed', () => {
+      const mockLana = { log: sinon.spy() };
+      window.lana = mockLana;
+      handle3in1IFrameEvents({ data: {}, origin: 'https://commerce.adobe.com' });
+      expect(window.lana.log.calledOnce).to.be.false;
+      delete window.lana;
+    });
+
+    it('should log to window.lana when available', () => {
+      const mockLana = { log: sinon.spy() };
+      window.lana = mockLana;
+      const message = {
+        app: 'ucv3',
+        subType: MSG_SUBTYPE.AppLoaded,
+      };
+      handle3in1IFrameEvents({ data: JSON.stringify(message), origin: 'https://commerce.adobe.com' });
+      expect(mockLana.log.calledWith('3-in-1 modal: AppLoaded')).to.be.true;
+      delete window.lana;
+    });
+
+    it('should handle unknown message subTypes gracefully (default case)', () => {
+      const message = {
+        app: 'ucv3',
+        subType: 'UNKNOWN_SUBTYPE',
+      };
+      expect(() => handle3in1IFrameEvents({ data: JSON.stringify(message) })).to.not.throw();
     });
   });
 
@@ -220,6 +253,70 @@ describe('Three-in-One Modal', () => {
       expect(content.querySelector('iframe')).to.exist;
       expect(content.querySelector('iframe').src).to.equal(testUrl);
       expect(content.querySelector('iframe').classList.contains('loading')).to.be.true;
+    });
+
+    it('should detect Mobile Safari and omit loading="lazy" attribute', () => {
+      const originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+      });
+      const testUrl = 'https://test.com/';
+      const content = createContent(testUrl);
+      const iframe = content.querySelector('iframe');
+      expect(iframe.hasAttribute('loading')).to.be.false;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: originalUserAgent,
+      });
+    });
+
+    it('should add loading="lazy" attribute for non-Mobile Safari browsers', () => {
+      const originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      });
+      const testUrl = 'https://test.com/';
+      const content = createContent(testUrl);
+      const iframe = content.querySelector('iframe');
+      expect(iframe.getAttribute('loading')).to.equal('lazy');
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: originalUserAgent,
+      });
+    });
+
+    it('should handle iPad user agent (Mobile Safari)', () => {
+      const originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: 'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+      });
+      const testUrl = 'https://test.com/';
+      const content = createContent(testUrl);
+      const iframe = content.querySelector('iframe');
+      expect(iframe.hasAttribute('loading')).to.be.false;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: originalUserAgent,
+      });
+    });
+
+    it('should handle Chrome on iOS (not Mobile Safari)', () => {
+      const originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1',
+      });
+      const testUrl = 'https://test.com/';
+      const content = createContent(testUrl);
+      const iframe = content.querySelector('iframe');
+      expect(iframe.getAttribute('loading')).to.equal('lazy');
+      Object.defineProperty(navigator, 'userAgent', {
+        writable: true,
+        value: originalUserAgent,
+      });
     });
   });
 
@@ -276,6 +373,248 @@ describe('Three-in-One Modal', () => {
       await checkoutLink.render();
       expect(checkoutLink).to.exist;
       expect(checkoutLink.href).to.include('rf=uc_segmentation_hide_tabs_cr');
+    });
+  });
+});
+
+describe('Three-in-One XSS Sanitization', () => {
+  describe('decodeUrl', () => {
+    it('should return URL unchanged when no decoding needed', () => {
+      expect(decodeUrl('https://example.com/path?query=value')).to.equal('https://example.com/path?query=value');
+      expect(decodeUrl('/relative/path')).to.equal('/relative/path');
+    });
+
+    it('should decode URL encoded once', () => {
+      expect(decodeUrl('https%3A//example.com')).to.equal('https://example.com');
+      expect(decodeUrl('https://example.com/path%3Fquery%3Dvalue')).to.equal('https://example.com/path?query=value');
+      expect(decodeUrl('hello%20world')).to.equal('hello world');
+    });
+
+    it('should decode URL encoded multiple times', () => {
+      expect(decodeUrl('https%253A//example.com')).to.equal('https://example.com');
+      expect(decodeUrl('hello%2520world')).to.equal('hello world');
+      expect(decodeUrl('https%25253A//example.com')).to.equal('https://example.com');
+      expect(decodeUrl('hello%252520world')).to.equal('hello world');
+      expect(decodeUrl('https%2525253A//example.com')).to.equal('https://example.com');
+      expect(decodeUrl('https%252525253A//example.com')).to.equal('https://example.com');
+    });
+
+    it('should stop at maximum iterations (5)', () => {
+      const sixTimesEncoded = 'https%25252525253A//example.com';
+      const expectedAfter5Decodes = 'https%3A//example.com';
+      expect(decodeUrl(sixTimesEncoded)).to.equal(expectedAfter5Decodes);
+      const sevenTimesEncoded = 'https%2525252525253A//example.com';
+      const expectedAfter5DecodesFrom7 = 'https%253A//example.com';
+      expect(decodeUrl(sevenTimesEncoded)).to.equal(expectedAfter5DecodesFrom7);
+    });
+
+    it('should handle malformed percent encoding gracefully', () => {
+      expect(decodeUrl('https://example.com%')).to.equal('https://example.com%');
+      expect(decodeUrl('https://example.com%2')).to.equal('https://example.com%2');
+      expect(decodeUrl('https://example.com%GG')).to.equal('https://example.com%GG');
+    });
+
+    it('should handle edge cases', () => {
+      expect(decodeUrl('')).to.equal(null);
+      expect(decodeUrl(null)).to.equal(null);
+      expect(decodeUrl(undefined)).to.equal(null);
+    });
+
+    it('should handle potential XSS payloads in encoded form', () => {
+      // eslint-disable-next-line no-script-url
+      expect(decodeUrl('javascript%253Aalert%25281%2529'))
+        // eslint-disable-next-line no-script-url
+        .to.equal('javascript:alert(1)');
+      expect(decodeUrl('data%253Atext%252Fhtml%252C%253Cscript%253Ealert%25281%2529%253C%252Fscript%253E'))
+        .to.equal('data:text/html,<script>alert(1)</script>');
+    });
+  });
+
+  describe('normalizeUrl', () => {
+    it('should return normal URLs unchanged', () => {
+      expect(normalizeUrl('https://example.com/path?query=value')).to.equal('https://example.com/path?query=value');
+      expect(normalizeUrl('/relative/path')).to.equal('/relative/path');
+    });
+
+    it('should trim whitespace from URLs', () => {
+      expect(normalizeUrl('  https://example.com  ')).to.equal('https://example.com');
+      expect(normalizeUrl('\t\nhttps://example.com\r\n')).to.equal('https://example.com');
+    });
+
+    it('should remove ASCII control characters', () => {
+      expect(normalizeUrl('https://example.com\x00')).to.equal('https://example.com');
+      expect(normalizeUrl('https://\x01example.com')).to.equal('https://example.com');
+    });
+
+    it('should remove Unicode control characters', () => {
+      expect(normalizeUrl('https://example.com\u0000')).to.equal('https://example.com');
+      expect(normalizeUrl('https://\u001fexample.com')).to.equal('https://example.com');
+      expect(normalizeUrl('https://example.com\u007f')).to.equal('https://example.com');
+      expect(normalizeUrl('https://example\u009f.com')).to.equal('https://example.com');
+      expect(normalizeUrl('https://example\u2000.com')).to.equal('https://example.com');
+      expect(normalizeUrl('https://example\u200d.com')).to.equal('https://example.com');
+      expect(normalizeUrl('https://example.com\ufeff')).to.equal('https://example.com');
+    });
+
+    it('should return null for dangerous protocols', () => {
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('javascript:alert(1)')).to.be.null;
+      expect(normalizeUrl('data:text/html,<script>alert(1)</script>')).to.be.null;
+      expect(normalizeUrl('vbscript:alert(1)')).to.be.null;
+      expect(normalizeUrl('file:///etc/passwd')).to.be.null;
+      expect(normalizeUrl('about:blank')).to.be.null;
+      expect(normalizeUrl('chrome://settings')).to.be.null;
+      expect(normalizeUrl('chrome-extension://abc123/popup.html')).to.be.null;
+      expect(normalizeUrl('filesystem:https://example.com/file')).to.be.null;
+      expect(normalizeUrl('blob:https://example.com/abc123')).to.be.null;
+      expect(normalizeUrl('mailto:user@example.com')).to.be.null;
+      expect(normalizeUrl('tel:+1234567890')).to.be.null;
+      expect(normalizeUrl('sms:+1234567890')).to.be.null;
+    });
+
+    it('should handle case-insensitive dangerous protocols', () => {
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('JAVASCRIPT:alert(1)')).to.be.null;
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('JavaScript:alert(1)')).to.be.null;
+      expect(normalizeUrl('DATA:text/html,<script>alert(1)</script>')).to.be.null;
+      expect(normalizeUrl('VbScript:alert(1)')).to.be.null;
+      expect(normalizeUrl('FILE:///etc/passwd')).to.be.null;
+      expect(normalizeUrl('CHROME://settings')).to.be.null;
+      expect(normalizeUrl('MAILTO:user@example.com')).to.be.null;
+    });
+
+    it('should handle URLs that become empty after normalization', () => {
+      expect(normalizeUrl('')).to.equal('');
+      expect(normalizeUrl('   ')).to.equal('');
+      expect(normalizeUrl('\x00\x01\x1f\x7f')).to.equal('');
+      expect(normalizeUrl('\u0000\u001f\u007f\u009f')).to.equal('');
+      expect(normalizeUrl('   \t\n\r   ')).to.equal('');
+    });
+
+    it('should handle mixed control characters and valid content', () => {
+      expect(normalizeUrl('https://\x00example\x01.com\x1f')).to.equal('https://example.com');
+      expect(normalizeUrl('  https://\u0000example\u001f.com\u200d  ')).to.equal('https://example.com');
+      expect(normalizeUrl('/path\x0a/to\x0d/resource')).to.equal('/path/to/resource');
+    });
+
+    it('should handle protocol-like strings that are not dangerous', () => {
+      expect(normalizeUrl('custom-protocol://example.com')).to.equal('custom-protocol://example.com');
+      expect(normalizeUrl('myapp://action?param=value')).to.equal('myapp://action?param=value');
+      expect(normalizeUrl('ws://example.com')).to.equal('ws://example.com');
+      expect(normalizeUrl('wss://example.com')).to.equal('wss://example.com');
+    });
+
+    it('should handle complex malicious payloads', () => {
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('java\x00script:alert(1)')).to.be.null;
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('java\u0000script:alert(1)')).to.be.null;
+      expect(normalizeUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')).to.be.null;
+      // eslint-disable-next-line no-script-url
+      expect(normalizeUrl('Java\x01Script:alert(1)')).to.be.null;
+    });
+  });
+
+  describe('isHttps', () => {
+    it('should return valid HTTPS Adobe.com URLs', () => {
+      expect(isHttps('https://adobe.com')).to.equal('https://adobe.com/');
+      expect(isHttps('http://commerce.adobe.com')).to.be.null;
+    });
+  });
+
+  describe('sanitizeUrl', () => {
+    it('should return null for invalid inputs', () => {
+      expect(sanitizeUrl(null)).to.be.null;
+      expect(sanitizeUrl(undefined)).to.be.null;
+      expect(sanitizeUrl('')).to.be.null;
+      expect(sanitizeUrl(false)).to.be.null;
+      expect(sanitizeUrl(0)).to.be.null;
+      expect(sanitizeUrl(123)).to.be.null;
+      expect(sanitizeUrl({})).to.be.null;
+      expect(sanitizeUrl([])).to.be.null;
+    });
+
+    it('should successfully process valid Adobe HTTPS URLs through the entire pipeline', () => {
+      expect(sanitizeUrl('https://adobe.com')).to.equal('https://adobe.com/');
+      expect(sanitizeUrl('https://commerce.adobe.com/path')).to.equal('https://commerce.adobe.com/path');
+      expect(sanitizeUrl('/relative/path')).to.equal('/relative/path');
+    });
+
+    it('should handle URLs requiring decoding + normalization + domain validation', () => {
+      expect(sanitizeUrl('https%3A//adobe.com')).to.equal('https://adobe.com/');
+      expect(sanitizeUrl('https%3A//commerce.adobe.com%2Fpath')).to.equal('https://commerce.adobe.com/path');
+      expect(sanitizeUrl('https://adobe.com\x00/path')).to.equal('https://adobe.com/path');
+      expect(sanitizeUrl('  https://commerce.adobe.com  ')).to.equal('https://commerce.adobe.com/');
+    });
+
+    it('should reject URLs that fail at the normalization step (dangerous protocols)', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeUrl('javascript:alert(1)')).to.be.null;
+      expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).to.be.null;
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeUrl('javascript%3Aalert%281%29')).to.be.null;
+      expect(sanitizeUrl('data%3Atext%2Fhtml%2Ctest')).to.be.null;
+    });
+
+    it('should handle complex scenarios with multiple encoding levels + normalization', () => {
+      expect(sanitizeUrl('https%253A//adobe.com\x00')).to.equal('https://adobe.com/');
+      expect(sanitizeUrl('  https%25253A//commerce.adobe.com  ')).to.equal('https://commerce.adobe.com/');
+      expect(sanitizeUrl('https%3A//adobe.com%2Fpath%3Fparam%3Dvalue')).to.equal('https://adobe.com/path?param=value');
+    });
+
+    it('should handle malformed URLs that cause URL constructor errors', () => {
+      expect(sanitizeUrl('https://')).to.be.null;
+      expect(sanitizeUrl('https://adobe.com:99999999')).to.be.null;
+      expect(sanitizeUrl('https://[invalid-ipv6]')).to.be.null;
+    });
+
+    it('should handle URLs that become invalid after decoding', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeUrl('javascript%253Aalert%25281%2529')).to.be.null;
+      expect(sanitizeUrl('https%3A//')).to.be.null;
+    });
+
+    it('should handle edge cases in the pipeline', () => {
+      expect(sanitizeUrl('%20%20%20')).to.be.null;
+      expect(sanitizeUrl('\x00\x01\x1f')).to.be.null;
+      expect(sanitizeUrl('\u0000\u001f\u007f')).to.be.null;
+    });
+  });
+
+  describe('sanitizeTarget', () => {
+    it('should return _blank for falsy values', () => {
+      expect(sanitizeTarget(null)).to.equal('_blank');
+      expect(sanitizeTarget(undefined)).to.equal('_blank');
+      expect(sanitizeTarget('')).to.equal('_blank');
+      expect(sanitizeTarget(false)).to.equal('_blank');
+      expect(sanitizeTarget(0)).to.equal('_blank');
+    });
+
+    it('should return valid standard target values', () => {
+      expect(sanitizeTarget('_blank')).to.equal('_blank');
+      expect(sanitizeTarget('_self')).to.equal('_self');
+      expect(sanitizeTarget('_parent')).to.equal('_parent');
+      expect(sanitizeTarget('_top')).to.equal('_top');
+    });
+
+    it('should return _blank for targets with invalid characters', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeTarget('javascript:alert(1)')).to.equal('_blank');
+      expect(sanitizeTarget('_blank onclick="alert(1)"')).to.equal('_blank');
+      expect(sanitizeTarget('my window')).to.equal('_blank');
+      expect(sanitizeTarget('window.open')).to.equal('_blank');
+      expect(sanitizeTarget('window[0]')).to.equal('_blank');
+      expect(sanitizeTarget('window+1')).to.equal('_blank');
+      expect(sanitizeTarget('<script>alert(1)</script>')).to.equal('_blank');
+    });
+
+    it('should handle complex malicious payloads', () => {
+      expect(sanitizeTarget('"><script>alert(1)</script>')).to.equal('_blank');
+      expect(sanitizeTarget("' onload='alert(1)")).to.equal('_blank');
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeTarget('javascript://example.com/%0Aalert(1)')).to.equal('_blank');
+      expect(sanitizeTarget('data:text/html,<script>alert(1)</script>')).to.equal('_blank');
     });
   });
 });


### PR DESCRIPTION
Added URL and target parameter sanitization to prevent XSS attacks in the three-in-one modal's postMessage handler. The sanitization validates the origin, blocks dangerous protocols (`javascript:`, `data:`, `vbscript:`, `file:` etc) while allowing legitimate HTTP/HTTPS and relative URLs. Invalid window target values now default to `_blank` for safety. Blocked attempts are logged to Lana for security monitoring.

Resolves: [MWPW-182221](https://jira.corp.adobe.com/browse/MWPW-182221)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/mirafedas/3in1-test-page?martech=off
- After: https://mwpw-182221-3in1-xss--milo--adobecom.aem.page/drafts/mirafedas/3in1-test-page#mini-plans-web-cta-illustrator-card?martech=off


















